### PR TITLE
PROPOSAL: Add jest matcher toThrowIntegrationAPIError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added jest matcher `toThrowIntegrationAPIError` to verify that errors are
+  properly thrown
+
 ### Fixed
 
 - Fixed the `url`, `status`, and `statusText` properties passed into


### PR DESCRIPTION
This is a demo of one way we could start to test/validate that our API errors are useful to our customers.
