### PR TITLE
INT-6041 - Duplicate key issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue related to duplicate keys when project has more than one pipeline
+  for a repository hosted on Azure DevOps.
+
 ## 2.0.0 - 2022-10-18
 
 ### Updated

--- a/src/steps/repos/index.ts
+++ b/src/steps/repos/index.ts
@@ -61,31 +61,33 @@ export async function fetchRepositories({
               await jobState.addRelationship(relationship);
             }
           } else {
-            const repositoryEntity = await jobState.addEntity(
-              createIntegrationEntity({
-                entityData: {
-                  source: repository,
-                  assign: {
-                    _type: 'azure_devops_repo',
-                    _class: 'CodeRepo',
-                    _key: `azure_devops_repo:${repository.id}`,
-                    defaultBranch: repository.defaultBranch,
-                    fullName: repository.name,
-                    id: repository.id,
-                    webLink: repository.url,
-                    type: repository.type,
-                  },
+            const repositoryEntity = createIntegrationEntity({
+              entityData: {
+                source: repository,
+                assign: {
+                  _type: 'azure_devops_repo',
+                  _class: 'CodeRepo',
+                  _key: `azure_devops_repo:${repository.id}`,
+                  defaultBranch: repository.defaultBranch,
+                  fullName: repository.name,
+                  id: repository.id,
+                  webLink: repository.url,
+                  type: repository.type,
                 },
-              }),
-            );
+              },
+            });
 
-            await jobState.addRelationship(
-              createDirectRelationship({
-                _class: RelationshipClass.USES,
-                from: projectEntity,
-                to: repositoryEntity,
-              }),
-            );
+            if (!(await jobState.hasKey(repositoryEntity._key))) {
+              await jobState.addEntity(repositoryEntity);
+
+              await jobState.addRelationship(
+                createDirectRelationship({
+                  _class: RelationshipClass.USES,
+                  from: projectEntity,
+                  to: repositoryEntity,
+                }),
+              );
+            }
           }
         },
       );


### PR DESCRIPTION
## Problem:
When a project has more than one pipelines for a repository hosted on Azure DevOps, the integration attempts to create an entity and a relationship for the same repository which causes the duplicate key error. This is highly likely to occur for clients where they use ADO as their main git hosting and uses separate pipelines for testing/build/deployments etc.

## Solution:
Ingest entity and build relationship between project and coderepo only once, skip when there's duplication.

## Notes:
- Information about the pipeline setup will be lost but it's acceptable since the relationship we are building is `PROJECT_USES_CODEREPO`
- To fully ingest this information on the graph, one suggestion is that we expand the relationship into `PROJECT_HAS_PIPELINE` and `PIPELINE_USES_CODEREPO` 